### PR TITLE
Allow mirrorlist and failovermethod parameters.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,10 @@ if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   # rake must be v10 for ruby 1.8.7
   gem 'rake', '~> 10.0'
 end
+
+if RUBY_VERSION < '2.0'
+  # json 2.x requires ruby 2.0. Lock to 1.8
+  gem 'json', '~> 1.8'
+  # json_pure 2.0.2 requires ruby 2.0. Lock to 2.0.1
+  gem 'json_pure', '= 2.0.1'
+end

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -31,6 +31,8 @@ define yum::repo (
   $password             = undef,
   $description          = undef,
   $environment          = $::environment,
+  $mirrorlist           = undef,
+  $failovermethod       = undef,
 ) {
 
   validate_string($username)
@@ -45,7 +47,9 @@ define yum::repo (
   # $baseurl is used in template and takes a form such as
   # http://yum.domain.tld/customrepo/5/8/dev/x86_64
   if $baseurl == 'UNSET' {
-    if $username != undef and $password != undef {
+    if $mirrorlist != undef {
+      $my_baseurl = undef
+    } elsif $username != undef and $password != undef {
       $my_baseurl = "${repo_server_protocol}://${username}:${password}@${repo_server}/${repo_server_basedir}/${name}/${::lsbmajdistrelease}/${::lsbminordistrelease}/${environment}/\$basearch"
     } else {
       $my_baseurl = "${repo_server_protocol}://${repo_server}/${repo_server_basedir}/${name}/${::lsbmajdistrelease}/${::lsbminordistrelease}/${environment}/\$basearch"

--- a/templates/repo.erb
+++ b/templates/repo.erb
@@ -3,8 +3,16 @@
 
 [<%= @name %>]
 name=<%= @description_real %>
+<% if @my_baseurl != nil -%>
 baseurl=<%= @my_baseurl %>
+<% end -%>
 enabled=<%= @enabled %>
 gpgcheck=<%= @gpgcheck %>
+<% if @mirrorlist != nil -%>
+mirrorlist=<%= @mirrorlist %>
+<% end -%>
+<% if @failovermethod != nil -%>
+failovermethod=<%= @failovermethod %>
+<% end -%>
 <% if @use_gpgkey_uri == true %>gpgkey=<%= @my_gpgkey %><% end %>
 <% if @priority != 'UNSET' %>priority=<%= @priority %><% end %>


### PR DESCRIPTION
Adds two new params to `yum::repo` to allow mirror lists. If both mirrorlist and baseurl are passed, both are put in the config. This is consistent with vanilla `yumrepo` behavior.

If mirrorlist is provided but baseurl is not, it no longer tries to guess the baseurl.