### PR TITLE
Fix compatibility with Puppet 4.0 to 4.3

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,7 @@ define yum::repo (
   $repo_file_mode       = '0400',
   $yum_repos_d_path     = '/etc/yum.repos.d',
   $gpgkey_url_proto     = 'http',
-  $gpgkey_url_server    = $repo_server,
+  $gpgkey_url_server    = undef,
   $gpgkey_url_path      = 'keys',
   $gpgkey_file_prefix   = 'RPM-GPG-KEY',
   $gpgkey_local_path    = '/etc/pki/rpm-gpg',
@@ -41,6 +41,20 @@ define yum::repo (
     $mirrorlist,
     $failovermethod,
   )
+
+  if is_domain_name($repo_server) == false or is_string($repo_server) == false {
+    fail("yum::repo::repo_server is not a domain name. It is <${repo_server}>.")
+  }
+
+  if is_string($gpgkey_url_server) == true and is_domain_name($gpgkey_url_server) == true {
+    $gpgkey_url_server_real = $gpgkey_url_server
+  }
+  elsif $gpgkey_url_server == undef {
+    $gpgkey_url_server_real = $repo_server
+  }
+  else {
+    fail("yum::repo::gpgkey_url_server is not a domain name. It is <${gpgkey_url_server}>.")
+  }
 
   if $description == undef {
     $description_real = $name
@@ -69,7 +83,7 @@ define yum::repo (
   # http://yum.domain.tld/keys/RPM-GPG-KEY-CUSTOMREPO-5
   if $gpgkey == 'UNSET' {
     if $use_gpgkey_uri == true {
-      $my_gpgkey = "${gpgkey_url_proto}://${gpgkey_url_server}/${gpgkey_url_path}/${gpgkey_file_prefix}-${upcase_name}-${::lsbmajdistrelease}"
+      $my_gpgkey = "${gpgkey_url_proto}://${gpgkey_url_server_real}/${gpgkey_url_path}/${gpgkey_file_prefix}-${upcase_name}-${::lsbmajdistrelease}"
     } else {
       $my_gpgkey = $gpgkey
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -131,11 +131,9 @@ describe 'yum' do
         :repos => {
           'rspec' => {
             'gpgcheck'          => '1',
-            'gpgkey_url_server' => 'workaround.issue.#6', # https://github.com/ghoneycutt/puppet-module-yum/issues/6
           },
           'test' => {
             'repo_file_mode'    => '0242',
-            'gpgkey_url_server' => 'workaround.issue.#6', # https://github.com/ghoneycutt/puppet-module-yum/issues/6
           }
         }
       }

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -235,6 +235,12 @@ describe 'yum::repo' do
 
     validations = {
       # /!\ Downgrade for Puppet 3.x: remove fixnum and float from invalid list
+      'domain_name' => {
+        :name    => %w(repo_server gpgkey_url_server),
+        :valid   => %w(v.al.id val.id),
+        :invalid => ['in,val.id', 'in_val.id', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
+        :message => 'is not a domain name',
+      },
       'string' => {
         :name    => %w(username password mirrorlist failovermethod),
         :valid   => ['string'],


### PR DESCRIPTION
Fix the issue that $gpgkey_url_server used the value of $repo_server in the
parameter list which is not supported by Puppet 4.0 to 4.3.

This fixes issue https://github.com/ghoneycutt/puppet-module-yum/issues/6