### PR TITLE
Add yum::repo ensure => absent functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ end
 
 gem 'facter', '>= 2.2.0'
 gem 'rspec-puppet', '~> 2.0'
-gem 'puppet-lint', '~> 2.0'
+# 2017-09-27 Pinned until 2.3.1 issue is resolved.
+# Check: https://github.com/rodjek/puppet-lint/issues/759
+gem 'puppet-lint', '2.3.0'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'

--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ Manage individual yum repo files in /etc/yum.repos.d
 ### Parameters
 
 ---
+#### ensure (string)
+Set to `"present"` or `"absent"`.  When absent, removes the repository
+configuration file from the node modeled on the behavior of the File type's
+ensure parameter.
+
+- *Default*: `"present"`
+
+---
 #### baseurl (string)
 Trigger to set the `baseurl` parameter of the repository configuration. Takes a form such as 'http://yum.domain.tld/customrepo/5/8/dev/x86_64'.
 

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -232,6 +232,17 @@ describe 'yum::repo' do
     it { should contain_file('rspec.repo').with_content(/\[rspec\][\s\S]*sslcacert=\/path\/to\/cert/) }
   end
 
+  context 'with ensure set to valid string "absent"' do
+    let(:params) { mandatory_params.merge({ :ensure => 'absent' }) }
+    it { should contain_file('rspec.repo').with_ensure('absent') }
+    it { is_expected.to have_yum__rpm_gpg_key_resource_count(0) }
+  end
+
+  context 'with ensure set to valid string "present"' do
+    let(:params) { mandatory_params.merge({ :ensure => 'present' }) }
+    it { should contain_file('rspec.repo').with_ensure('file') }
+  end
+
   describe 'variable type and content validations' do
     let(:mandatory_params) { mandatory_params }
 
@@ -278,6 +289,12 @@ describe 'yum::repo' do
         :valid   => ['string'],
         :invalid => [%w(array), { 'ha' => 'sh' }, true, false],
         :message => 'is not a string',
+      },
+      'present or absent' => {
+        :name    => %w(ensure),
+        :valid   => ['present', 'absent'],
+        :invalid => [true, false, 'file'],
+        :message => 'ensure must be present or absent',
       },
     }
 


### PR DESCRIPTION
Without this patch, puppet cannot easily remove specific yum
repositories.  This is a problem in situations where the
directory cannot be fully purged due to unmanaged files and
when a specific configuration needs to be removed from specific
nodes.