### PR TITLE
Expand acceptance tests to verify yum::server and yum::repo interactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ matrix:
       env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION="puppet5"
       bundler_args:
       script: bundle exec rake beaker
+    - rvm: 2.4.4
+      sudo: required
+      services: docker
+      env: BEAKER_set="centos-7-multi" BEAKER_PUPPET_COLLECTION="puppet5" BEAKER_yum_full="yes"
+      bundler_args:
+      script: bundle exec rake beaker
 
 notifications:
   email: false

--- a/spec/acceptance/00_yum_spec.rb
+++ b/spec/acceptance/00_yum_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'yum class' do
+describe 'yum class', unless: RSpec.configuration.yum_full do
   context 'yum' do
     context 'with default values for all parameters' do
       context 'it should be idempotent' do

--- a/spec/acceptance/01_updatesd_spec.rb
+++ b/spec/acceptance/01_updatesd_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'yum::updatesd class' do
+describe 'yum::updatesd class', unless: RSpec.configuration.yum_full do
   context 'yum::updatesd' do
     context 'with default values for all parameters' do
       context 'it should be idempotent' do

--- a/spec/acceptance/02_server_spec.rb
+++ b/spec/acceptance/02_server_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'yum::server class' do
+describe 'yum::server class', unless: RSpec.configuration.yum_full do
   context 'yum::server' do
     context 'with default values for all parameters' do
       context 'it should be idempotent' do

--- a/spec/acceptance/99_client_server_spec.rb
+++ b/spec/acceptance/99_client_server_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper_acceptance'
+
+describe 'yum::server class', if: RSpec.configuration.yum_full do
+  server = only_host_with_role(hosts, 'server')
+  client = only_host_with_role(hosts, 'client')
+  context 'yum::server' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+      include ::yum::server
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(server, pp, :catch_failures => true)
+      apply_manifest_on(server, pp, :catch_changes  => true)
+    end
+
+    it 'should create repo' do
+      on server, 'mkdir -p /opt/repos/cowsay/7'
+      on server, 'wget https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/cowsay-3.04-4.el7.noarch.rpm -O /opt/repos/cowsay/7/cowsay-3.04-4.el7.noarch.rpm'
+      on server, 'cd /opt/repos/cowsay/7 && createrepo -v .'
+    end
+  end
+  context 'yum::repo' do
+    it 'sould work with no errors' do
+      pp = <<-EOS
+      include ::yum
+      yum::repo { 'test':
+        description => 'Test yum-server serving up yum repos',
+        baseurl     => ['http://yum-server/cowsay/\$releasever/'],
+        enabled     => true,
+        gpgcheck    => false,
+      }
+      package { 'cowsay':
+        ensure  => 'installed',
+        require => Yum::Repo['test'],
+      }
+      EOS
+      apply_manifest_on(client, pp, :catch_failures => true)
+      apply_manifest_on(client, pp, :catch_changes  => true)
+    end
+
+    describe yumrepo('test'), :node => client  do
+      it { is_expected.to exist }
+      it { is_expected.to be_enabled }
+    end
+    describe package('cowsay'), :node => client do
+      it { is_expected.to be_installed }
+    end
+    it 'should have installed cowsay from test repo' do
+      on client, 'yum list | grep cowsay' do
+        repo = stdout.split()[2]
+        expect(repo).to eq('@test')
+      end
+    end
+  end
+end

--- a/spec/acceptance/nodesets/centos-6.yml
+++ b/spec/acceptance/nodesets/centos-6.yml
@@ -2,6 +2,8 @@ HOSTS:
   yum:
     roles:
       - agent
+      - client
+      - server
       - default
     platform: el-6-x86_64
     hypervisor: docker

--- a/spec/acceptance/nodesets/centos-7-multi.yml
+++ b/spec/acceptance/nodesets/centos-7-multi.yml
@@ -1,9 +1,8 @@
 HOSTS:
-  yum:
+  yum-client:
     roles:
       - agent
       - client
-      - server
       - default
     platform: el-7-x86_64
     hypervisor: docker
@@ -14,6 +13,19 @@ HOSTS:
     docker_image_commands:
       - 'yum install -y wget'
     docker_container_name: 'yum-client-el7'
+  yum-server:
+    roles:
+      - agent
+      - server
+    platform: el-7-x86_64
+    hypervisor: docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd:
+      - '/usr/sbin/init'
+    docker_image_commands:
+      - 'yum install -y wget'
+    docker_container_name: 'yum-server-el7'
 CONFIG:
   log_level: debug
   type: aio

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,6 +13,8 @@ UNSUPPORTED_PLATFORMS = ['Suse','AIX','Solaris']
 RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
+  c.add_setting :yum_full, default: false
+  c.yum_full = (ENV['BEAKER_yum_full'] == 'yes' || ENV['BEAKER_yum_full'] == 'true')
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module dependencies


### PR DESCRIPTION
This works very much like the existing tests in Vagrant.